### PR TITLE
Show owner of a znetview

### DIFF
--- a/Utilities/HoverAdditions.cs
+++ b/Utilities/HoverAdditions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text;
 using UnityEngine;
 
@@ -52,14 +53,17 @@ namespace XRayVision.Utilities
                     }
 
 
-                    if (view?.m_zdo.GetString("creatorName").Length > 1)
+                    if (view.m_zdo.GetString("creatorName").Length > 1)
                         stringBuilder.Append(
-                            $"\n<color={XRayVisionPlugin._creatorNameColor.Value}>{XRayVisionPlugin._leftSeperator.Value}Creator Name{XRayVisionPlugin._rightSeperator.Value}  {view?.m_zdo.GetString("creatorName")}</color>");
+                            $"\n<color={XRayVisionPlugin._creatorNameColor.Value}>{XRayVisionPlugin._leftSeperator.Value}Creator Name{XRayVisionPlugin._rightSeperator.Value}  {view.m_zdo.GetString("creatorName")}</color>");
 
 
-                    if (view?.m_zdo.GetString("steamName").Length > 1)
+                    if (view.m_zdo.GetString("steamName").Length > 1)
                         stringBuilder.Append(
-                            $"\n<color={XRayVisionPlugin._creatorSteamInfoColor.Value}>{XRayVisionPlugin._leftSeperator.Value}Creator Steam Info{XRayVisionPlugin._rightSeperator.Value}  {view?.m_zdo.GetString("steamName")} × {view?.m_zdo.GetString("steamID")}</color>");
+                            $"\n<color={XRayVisionPlugin._creatorSteamInfoColor.Value}>{XRayVisionPlugin._leftSeperator.Value}Creator Steam Info{XRayVisionPlugin._rightSeperator.Value}  {view.m_zdo.GetString("steamName")} × {view.m_zdo.GetString("steamID")}</color>");
+
+                    stringBuilder.Append(
+                            $"\n<color={XRayVisionPlugin._ownerColor.Value}>{XRayVisionPlugin._leftSeperator.Value}Owner{XRayVisionPlugin._rightSeperator.Value}  {GetOwnerText(view)}</color>");
 
                     return __result += "\n\n" + stringBuilder;
                 case true when !HoverTextDisplay:
@@ -72,6 +76,17 @@ namespace XRayVision.Utilities
                 default:
                     return __result;
             }
+        }
+
+        private static string GetOwnerText(ZNetView view) {
+            ZNet.PlayerInfo? owner = ZNet.instance.m_players.Where(i => i.m_characterID.userID == view.m_zdo.m_owner).Cast<ZNet.PlayerInfo?>().FirstOrDefault();
+
+            if (owner == null) {
+                return "-";
+            }
+
+            string ownerIsMe = view.IsOwner() ? "(Me)" : "";
+            return $"{owner?.m_name}, {view.m_zdo.m_owner} {ownerIsMe}";
         }
 
         public static string AddPlayerHoverText(GameObject gobj, ref string __result)

--- a/XRayVision.cs
+++ b/XRayVision.cs
@@ -55,6 +55,8 @@ namespace XRayVision
                 "Color of the Creator Name Hover text.", false);
             _creatorSteamInfoColor = config("Colors", "Creator Steam Info Color", "#95DBE5FF",
                 "Color of the Steam Information Hover text.", false);
+            _ownerColor = config("Colors", "Owner Info Color", "#c1eaf0",
+                "Color of the Owner Hover text.", false);
             _leftSeperator = config("Attribute Wrapper", "Left", "「",
                 "Text to be shown to the left of the attribute labels", false);
             _rightSeperator = config("Attribute Wrapper", "Right", "」",
@@ -109,6 +111,7 @@ namespace XRayVision
         internal static ConfigEntry<string>? _creatorIDColor;
         internal static ConfigEntry<string>? _creatorNameColor;
         internal static ConfigEntry<string>? _creatorSteamInfoColor;
+        internal static ConfigEntry<string>? _ownerColor;
         internal static ConfigEntry<string>? _leftSeperator;
         internal static ConfigEntry<string>? _rightSeperator;
 


### PR DESCRIPTION
Shows the current owner of the ZNetView object that is looked at.

Also removed some `view?`, it is already checked that it is not null and alive. The null propagation is faulty anyway as ZNetView is a Unity object,

![grafik](https://user-images.githubusercontent.com/39767545/163254083-00b07ee4-c513-4fd8-a2f8-c43af9df7cb0.png)
