### PR TITLE
Xbox Compatibility

### DIFF
--- a/Patches/WearNTear.cs
+++ b/Patches/WearNTear.cs
@@ -10,24 +10,19 @@ namespace XRayVision.Patches
         [HarmonyPrefix]
         private static void Prefix(WearNTear __instance)
         {
-            if (!__instance.m_nview.IsValid() || __instance.m_nview == null) return;
+            if (!__instance || !__instance.m_nview || !__instance.m_nview.IsValid()) return;
             if (__instance.gameObject.GetComponent<Hoverable>() == null)
             {
                 __instance.gameObject.AddComponent<HoverText>();
             }
 
-            string? steamID = readLocalSteamID();
-            if (__instance == null) return;
-            __instance.m_nview?.GetZDO().Set("creatorName", Player.m_localPlayer.GetPlayerName());
-            __instance.m_nview?.GetZDO()
-                .Set("steamName", SteamFriends.GetPersonaName());
-            __instance.m_nview?.GetZDO()
-                .Set("steamID", steamID);
+            ZNetPeer netPeer = ZNet.instance.GetServerPeer();
+
+            __instance.m_nview.GetZDO().Set("creatorName", Player.m_localPlayer.GetPlayerName());
+            __instance.m_nview.GetZDO().Set("steamID", netPeer.m_socket.GetHostName());
+
+            if (PlatformUtils.GetPlatform(netPeer) == PrivilegeManager.Platform.Steam)
+                __instance.m_nview.GetZDO().Set("steamName", SteamFriends.GetPersonaName());
         }
-
-
-        internal static string? readLocalSteamID() =>
-            Type.GetType("Steamworks.SteamUser, assembly_steamworks")?.GetMethod("GetSteamID")!
-                .Invoke(null, Array.Empty<object>()).ToString();
     }
 }

--- a/Utilities/HoverAdditions.cs
+++ b/Utilities/HoverAdditions.cs
@@ -193,11 +193,11 @@ namespace XRayVision.Utilities
         {
             if (view.m_zdo.GetString("steamName").Length > 1)
                 return clean
-                    ? $"\n{XRayVisionPlugin.LeftSeperator.Value}Creator Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamName")} × {view.m_zdo.GetString("steamID")}"
-                    : $"\n<color={XRayVisionPlugin.CreatorSteamInfoColor.Value}>{XRayVisionPlugin.LeftSeperator.Value}Creator Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamName")} × {view.m_zdo.GetString("steamID")}</color>";
+                    ? $"\n{XRayVisionPlugin.LeftSeperator.Value}Creator Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamName")} × {view.m_zdo.GetString("steamID")}"
+                    : $"\n<color={XRayVisionPlugin.CreatorSteamInfoColor.Value}>{XRayVisionPlugin.LeftSeperator.Value}Creator Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamName")} × {view.m_zdo.GetString("steamID")}</color>";
             return clean
-                ? $"\n{XRayVisionPlugin.LeftSeperator.Value}Creator Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamID")}"
-                : $"\n<color={XRayVisionPlugin.CreatorSteamInfoColor.Value}>{XRayVisionPlugin.LeftSeperator.Value}Creator Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamID")}</color>";
+                ? $"\n{XRayVisionPlugin.LeftSeperator.Value}Creator Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamID")}"
+                : $"\n<color={XRayVisionPlugin.CreatorSteamInfoColor.Value}>{XRayVisionPlugin.LeftSeperator.Value}Creator Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamID")}</color>";
         }
 
         public static string AddPlayerHoverText(GameObject gobj, ref string __result)
@@ -233,10 +233,10 @@ namespace XRayVision.Utilities
                             .Append("</color>");
                         if (view.m_zdo.GetString("steamName").Length >= 1)
                             stringBuilder.Append(
-                                $"\n<color=#95DBE5FF>{XRayVisionPlugin.LeftSeperator.Value}Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamName")} × {view.m_zdo.GetString("steamID")}</color>");
+                                $"\n<color=#95DBE5FF>{XRayVisionPlugin.LeftSeperator.Value}Player Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamName")} × {view.m_zdo.GetString("steamID")}</color>");
                         else if (view.m_zdo.GetString("steamID").Length >= 1)
                             stringBuilder.Append(
-                                $"\n<color=#95DBE5FF>{XRayVisionPlugin.LeftSeperator.Value}Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamID")}</color>");
+                                $"\n<color=#95DBE5FF>{XRayVisionPlugin.LeftSeperator.Value}Player Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamID")}</color>");
                     }
                     catch
                     {

--- a/Utilities/HoverAdditions.cs
+++ b/Utilities/HoverAdditions.cs
@@ -47,7 +47,7 @@ namespace XRayVision.Utilities
                     XRayVisionPlugin.ModeratorConfigs[XRayVisionPlugin.ID].ShowSteamInformation;
                 if (showSteamInformation!.Value)
                 {
-                    if (tuple.Item1.m_zdo.GetString("steamName").Length > 1)
+                    if (tuple.Item1.m_zdo.GetString("steamName").Length > 1 || tuple.Item1.m_zdo.GetString("steamID").Length > 1)
                     {
                         stringBuilder.Append(GetSteamInfoString(tuple.Item1, needItCleanJack));
                     }
@@ -55,7 +55,7 @@ namespace XRayVision.Utilities
             }
             else if (XRayVisionPlugin.IsAdmin)
             {
-                if (tuple.Item1.m_zdo.GetString("steamName").Length > 1)
+                if (tuple.Item1.m_zdo.GetString("steamName").Length > 1 || tuple.Item1.m_zdo.GetString("steamID").Length > 1)
                 {
                     stringBuilder.Append(GetSteamInfoString(tuple.Item1, needItCleanJack));
                 }
@@ -191,9 +191,13 @@ namespace XRayVision.Utilities
 
         private static string GetSteamInfoString(ZNetView view, bool clean = false)
         {
+            if (view.m_zdo.GetString("steamName").Length > 1)
+                return clean
+                    ? $"\n{XRayVisionPlugin.LeftSeperator.Value}Creator Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamName")} × {view.m_zdo.GetString("steamID")}"
+                    : $"\n<color={XRayVisionPlugin.CreatorSteamInfoColor.Value}>{XRayVisionPlugin.LeftSeperator.Value}Creator Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamName")} × {view.m_zdo.GetString("steamID")}</color>";
             return clean
-                ? $"\n{XRayVisionPlugin.LeftSeperator.Value}Creator Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamName")} × {view.m_zdo.GetString("steamID")}"
-                : $"\n<color={XRayVisionPlugin.CreatorSteamInfoColor.Value}>{XRayVisionPlugin.LeftSeperator.Value}Creator Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamName")} × {view.m_zdo.GetString("steamID")}</color>";
+                ? $"\n{XRayVisionPlugin.LeftSeperator.Value}Creator Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamID")}"
+                : $"\n<color={XRayVisionPlugin.CreatorSteamInfoColor.Value}>{XRayVisionPlugin.LeftSeperator.Value}Creator Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamID")}</color>";
         }
 
         public static string AddPlayerHoverText(GameObject gobj, ref string __result)
@@ -227,9 +231,12 @@ namespace XRayVision.Utilities
                                     .AddTicks(view.m_zdo.m_timeCreated - ZNet.instance.GetTime().Ticks)
                                     .ToString("g"))
                             .Append("</color>");
-                        if (view?.m_zdo.GetString("steamName").Length > 1)
+                        if (view.m_zdo.GetString("steamName").Length >= 1)
                             stringBuilder.Append(
-                                $"\n<color=#95DBE5FF>{XRayVisionPlugin.LeftSeperator.Value}Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view?.m_zdo.GetString("steamName")} × {view?.m_zdo.GetString("steamID")}</color>");
+                                $"\n<color=#95DBE5FF>{XRayVisionPlugin.LeftSeperator.Value}Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamName")} × {view.m_zdo.GetString("steamID")}</color>");
+                        else if (view.m_zdo.GetString("steamID").Length >= 1)
+                            stringBuilder.Append(
+                                $"\n<color=#95DBE5FF>{XRayVisionPlugin.LeftSeperator.Value}Steam Info{XRayVisionPlugin.RightSeperator.Value}  {view.m_zdo.GetString("steamID")}</color>");
                     }
                     catch
                     {

--- a/Utilities/PlatformUtils.cs
+++ b/Utilities/PlatformUtils.cs
@@ -1,0 +1,15 @@
+﻿namespace XRayVision
+{
+    public static class PlatformUtils
+    {
+        public static PrivilegeManager.Platform GetPlatform(string hostname)
+        {
+            return PrivilegeManager.ParseUser(hostname).platform;
+        }
+
+        public static PrivilegeManager.Platform GetPlatform(ZNetPeer netPeer)
+        {
+            return GetPlatform(netPeer.m_socket.GetHostName());
+        }
+    }
+}

--- a/XRayVision.csproj
+++ b/XRayVision.csproj
@@ -104,6 +104,7 @@
         <Compile Include="Utilities\Definitions.cs" />
         <Compile Include="Utilities\FileHandler.cs" />
         <Compile Include="Utilities\HoverAdditions.cs" />
+        <Compile Include="Utilities\PlatformUtils.cs" />
         <Compile Include="Utilities\RPCShit\Client.cs" />
         <Compile Include="Utilities\RPCShit\Server.cs" />
         <Compile Include="Utilities\VersionHandshake.cs" />


### PR DESCRIPTION
This fixes the errors that occur if the game is started with XBox/Gamepass. The SteamID is no longer directly accessed but the HostName is used. This also changes the display from `<steamId>` to `Steam_<steamid>`/`Xbox_<xboxid>`. The ZDO keys are not changed but the display only says "Creator Info", not "Creator Steam Info" anymore. I haven't toched the config names as I don't know how you want to handle them.